### PR TITLE
Fixes pick image from Picasa on Android < 3.0

### DIFF
--- a/src/com/beanie/imagechooser/api/ImageChooserManager.java
+++ b/src/com/beanie/imagechooser/api/ImageChooserManager.java
@@ -167,12 +167,19 @@ public class ImageChooserManager extends BChooser implements ImageProcessorListe
             if (Config.DEBUG) {
                 Log.i(TAG, "Got : " + uri);
             }
+            // Picasa on Android >= 3.0
             if (uri.startsWith("content:")) {
                 filePathOriginal = getAbsoluteImagePathFromUri(Uri.parse(data.getDataString()));
             }
+            // Picasa on Android < 3.0
+            if (uri.matches("https?://\\w+\\.googleusercontent\\.com/.+")) {
+                filePathOriginal = uri;
+            }
+            // Local storage
             if (uri.startsWith("file://")) {
                 filePathOriginal = data.getDataString().substring(7);
             }
+            
             if (filePathOriginal == null || TextUtils.isEmpty(filePathOriginal)) {
                 onError("File path was null");
             } else {


### PR DESCRIPTION
More details: https://code.google.com/p/android/issues/detail?id=21234#c17

I tested it on the Nexus One (Android 2.3.6).

VideoChooserManager.processVideoFromGallery should probably be changed to handle Picasa videos on older Android < 3.0 also.

Since both methods do the same, perhaps that code could be refactored.
