### PR TITLE
ADD build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,36 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:0.4.+'
+    }
+}
+apply plugin: 'android-library'
+
+dependencies {
+compile 'com.android.support:support-v4:13.0.0'
+}
+
+android {
+    compileSdkVersion 17
+    buildToolsVersion "17"
+
+    defaultConfig {
+        minSdkVersion 8
+        targetSdkVersion 17
+    }
+    sourceSets {
+        main {
+            manifest.srcFile 'AndroidManifest.xml'
+            java.srcDirs = ['src']
+            resources.srcDirs = ['src']
+            aidl.srcDirs = ['src']
+            renderscript.srcDirs = ['src']
+            res.srcDirs = ['res']
+            assets.srcDirs = ['assets']
+        }
+
+        instrumentTest.setRoot('tests')
+    }
+}


### PR DESCRIPTION
Would be nice if you could add a build.gradle to your project. 
The one i added works for me (Android Studio 0.19 compatible), but should be upgraded in case somebody uses
Android Studio 0.2

Since Android Studio 0.2 you have to use:
gradle:0.5

I am using the old version cause i did not upgrade all gradle scripts yet.
