### PR TITLE
Correct use of type (must be "video/*, image/*")

### DIFF
--- a/image-chooser-library/src/main/java/com/kbeanie/imagechooser/api/MediaChooserManager.java
+++ b/image-chooser-library/src/main/java/com/kbeanie/imagechooser/api/MediaChooserManager.java
@@ -177,7 +177,7 @@ public class MediaChooserManager extends BChooser implements
 	private void chooseMedia() throws Exception {
 		checkDirectory();
 		try {
-			Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+			Intent intent = new Intent(Intent.ACTION_PICK);
 			if (extras != null) {
 				intent.putExtras(extras);
 			}

--- a/image-chooser-library/src/main/java/com/kbeanie/imagechooser/api/MediaChooserManager.java
+++ b/image-chooser-library/src/main/java/com/kbeanie/imagechooser/api/MediaChooserManager.java
@@ -181,7 +181,7 @@ public class MediaChooserManager extends BChooser implements
 			if (extras != null) {
 				intent.putExtras(extras);
 			}
-			intent.setType("video/*, images/*");
+			intent.setType("video/*, image/*");
 			startActivity(intent);
 		} catch (ActivityNotFoundException e) {
 			throw new Exception("Activity not found");


### PR DESCRIPTION
Only video was showing, tested on API 21.