### PR TITLE
Uri.parse(filePath).getPath -> filePath

### DIFF
--- a/image-chooser-library/src/main/java/com/kbeanie/imagechooser/threads/MediaProcessorThread.java
+++ b/image-chooser-library/src/main/java/com/kbeanie/imagechooser/threads/MediaProcessorThread.java
@@ -215,7 +215,7 @@ public abstract class MediaProcessorThread extends Thread {
     private void copyFileToDir() throws Exception {
         try {
             File file;
-            file = new File(Uri.parse(filePath).getPath());
+            file = new File(filePath);
             File copyTo = new File(FileUtils.getDirectory(foldername)
                     + File.separator + file.getName());
             FileInputStream streamIn = new FileInputStream(file);


### PR DESCRIPTION
I have problem
filePath is "/storage/external_SD/#/#abc/zyx.jpg"
Uri.parse("/storage/external_SD/#/#abc/zyx.jpg").getPath return only "/storage/external_SD".
So FileNoeFoundException occured
Your code is File file = new File(Uri.parse(filePath).getPath)
I think variable filePath is already FILEPATH.
I thnkis Uri.parse.. is unnecessary code
please check this code
thank you
